### PR TITLE
Rst 1937 - ET3 Response to CCD

### DIFF
--- a/app/admin/admin_external_systems.rb
+++ b/app/admin/admin_external_systems.rb
@@ -25,7 +25,8 @@ ActiveAdmin.register ExternalSystem, as: 'External Systems' do
     column :reference
     column :office_codes
     column :enabled
-    column :export
+    column :export_claims
+    column :export_responses
     actions
   end
 
@@ -35,6 +36,8 @@ ActiveAdmin.register ExternalSystem, as: 'External Systems' do
       input :name
       input :reference
       input :enabled
+      input :export_claims
+      input :export_responses
       input :export_queue
       input :office_codes, as: :check_boxes, collection: Office.all.map {|o| [o.name, o.code]}
     end

--- a/app/admin/admin_external_systems.rb
+++ b/app/admin/admin_external_systems.rb
@@ -35,7 +35,7 @@ ActiveAdmin.register ExternalSystem, as: 'External Systems' do
       input :name
       input :reference
       input :enabled
-      input :export
+      input :export_queue
       input :office_codes, as: :check_boxes, collection: Office.all.map {|o| [o.name, o.code]}
     end
 

--- a/app/admin/admin_responses.rb
+++ b/app/admin/admin_responses.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register Response, as: 'Responses' do
 #   permitted
 # end
 
-  index do
+  index download_links: true do
     selectable_column
     id_column
     column :reference
@@ -22,8 +22,18 @@ ActiveAdmin.register Response, as: 'Responses' do
     column :case_number
     column :claimants_name
     column :created_at
-    actions
+    column :exports do |r|
+      r.exports.count
+    end
+    actions do
+      dropdown_menu 'Test' do
+        item "Item 1", "sdsfdsfsd"
+      end
+    end
   end
+
+
+
 
   show do |response|
     default_attribute_table_rows = active_admin_config.resource_columns
@@ -42,5 +52,17 @@ ActiveAdmin.register Response, as: 'Responses' do
   filter :reference
   filter :case_number
   filter :created_at
+
+
+  batch_action :export, form: {
+      external_system_id: ExternalSystem.pluck(:name, :id)
+  } do |ids, inputs|
+    response = Admin::ExportResponsesService.call(ids.map(&:to_i), inputs['external_system_id'].to_i)
+    if response.errors.present?
+      debug = 1
+    else
+      redirect_to admin_responses_path, notice: 'Responses queued for export'
+    end
+  end
 
 end

--- a/app/admin/admin_responses.rb
+++ b/app/admin/admin_responses.rb
@@ -25,11 +25,7 @@ ActiveAdmin.register Response, as: 'Responses' do
     column :exports do |r|
       r.exports.count
     end
-    actions do
-      dropdown_menu 'Test' do
-        item "Item 1", "sdsfdsfsd"
-      end
-    end
+    actions
   end
 
 
@@ -52,6 +48,10 @@ ActiveAdmin.register Response, as: 'Responses' do
   filter :reference
   filter :case_number
   filter :created_at
+
+  scope :all, default: true
+  scope :not_exported
+  scope :not_exported_to_ccd
 
 
   batch_action :export, form: {

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -16,4 +16,8 @@ class Claim < ApplicationRecord
     claimant = primary_claimant
     "#{claimant.title} #{claimant.first_name} #{claimant.last_name}"
   end
+
+  def as_json(options = {})
+    super(options.merge include: :uploaded_files)
+  end
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -2,5 +2,5 @@
 class Export < ApplicationRecord
   self.table_name = :exports
   belongs_to :resource, polymorphic: true
-  belongs_to :pdf_file, class_name: 'UploadedFile', optional: true
+  belongs_to :external_system
 end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -6,5 +6,5 @@ class Response < ApplicationRecord
   belongs_to :representative
   has_many :response_uploaded_files, dependent: :destroy
   has_many :uploaded_files, through: :response_uploaded_files
-
+  has_many :exports, as: :resource
 end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -7,4 +7,11 @@ class Response < ApplicationRecord
   has_many :response_uploaded_files, dependent: :destroy
   has_many :uploaded_files, through: :response_uploaded_files
   has_many :exports, as: :resource
+
+  scope :not_exported, -> { joins("LEFT JOIN \"exports\" ON \"exports\".\"resource_id\" = \"responses\".\"id\" AND \"exports\".\"resource_type\" = 'Response'").where(exports: {id: nil}) }
+  scope :not_exported_to_ccd, -> { joins("LEFT OUTER JOIN \"exports\" ON \"exports\".\"resource_id\" = \"responses\".\"id\" AND \"exports\".\"resource_type\" = 'Response' LEFT OUTER JOIN \"external_systems\" ON \"exports\".\"external_system_id\" = \"external_systems\".\"id\" AND \"external_systems\".\"reference\" ~ 'ccd'").where(external_systems: {id: nil}) }
+  def as_json(options = {})
+    super(options.merge include: :uploaded_files)
+  end
+
 end

--- a/app/services/admin/export_responses_service.rb
+++ b/app/services/admin/export_responses_service.rb
@@ -1,0 +1,39 @@
+module Admin
+  class ExportResponsesService
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    attribute :response_ids
+    attribute :external_system_id
+    attribute :base_url
+    def self.call(response_ids, external_system_id, base_url: ENV.fetch('ET_API_URL'))
+      new(response_ids: response_ids, external_system_id: external_system_id, base_url: base_url).call
+    end
+
+    def call
+      response = HTTParty.post("#{base_url}/v2/exports/export_responses",
+                               headers: {
+                                   'Accept': 'application/json',
+                                   'Content-Type': 'application/json'
+                               },
+                               body: {
+                                   uuid: SecureRandom.uuid,
+                                   command: 'ExportResponses',
+                                   data: {
+                                       response_ids: response_ids,
+                                       external_system_id: external_system_id
+                                   },
+                                   async: false
+                               }.to_json)
+      return self if response.success?
+
+      if response['errors']
+        response['errors'].each do |err|
+          errors.add err['source'].gsub(/\A\//, '').to_sym, err['detail'], error: err['code']
+        end
+      else
+        errors.add :base, :http_error, status_code: response.status.to_sym
+      end
+      self
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,4 +62,5 @@ Rails.application.configure do
 
   config.et_atos_api.username = 'atos'
   config.et_atos_api.password = 'password'
+  config.hosts.clear
 end


### PR DESCRIPTION



### JIRA link (if applicable) ###
RST-1937


### Change description ###
This PR allows for the management of ET3 responses which wont get automatically exported to CCD, instead, the user filters for 'Unexported Responses', checks a response's case number - makes sure it is the right one then exports it.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
