### PR TITLE
Rst 2318 multiples csv export

### DIFF
--- a/app/admin/admin_uploaded_files.rb
+++ b/app/admin/admin_uploaded_files.rb
@@ -13,7 +13,7 @@ ActiveAdmin.register UploadedFile, as: 'UploadedFiles' do
 # end
   permit_params :file, :filename
   permit_params do
-    return [] unless action == :export_ccd_multiples
+    return [] unless action_name == 'export_ccd_multiples'
     return [:case_type_id]
   end
 

--- a/app/admin/admin_uploaded_files.rb
+++ b/app/admin/admin_uploaded_files.rb
@@ -11,11 +11,7 @@ ActiveAdmin.register UploadedFile, as: 'UploadedFiles' do
 #   permitted << :other if params[:action] == 'create' && current_user.admin?
 #   permitted
 # end
-  permit_params :file, :filename
-  permit_params do
-    return [] unless action_name == 'export_ccd_multiples'
-    return [:case_type_id]
-  end
+  permit_params :file, :filename, :case_type_id
 
   preserve_default_filters!
   remove_filter :file_attachment, :file_blob, :checksum

--- a/app/admin/admin_uploaded_files.rb
+++ b/app/admin/admin_uploaded_files.rb
@@ -11,7 +11,7 @@ ActiveAdmin.register UploadedFile, as: 'UploadedFiles' do
 #   permitted << :other if params[:action] == 'create' && current_user.admin?
 #   permitted
 # end
-  permit_params :file, :filename, :case_type_id
+  permit_params :file, :filename
 
   preserve_default_filters!
   remove_filter :file_attachment, :file_blob, :checksum

--- a/app/admin/admin_uploaded_files.rb
+++ b/app/admin/admin_uploaded_files.rb
@@ -11,6 +11,7 @@ ActiveAdmin.register UploadedFile, as: 'UploadedFiles' do
 #   permitted << :other if params[:action] == 'create' && current_user.admin?
 #   permitted
 # end
+  permit_params :file, :filename
 
   preserve_default_filters!
   remove_filter :file_attachment, :file_blob, :checksum
@@ -29,6 +30,15 @@ ActiveAdmin.register UploadedFile, as: 'UploadedFiles' do
     column :filename
     column :created_at
     column :content_type
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :filename
+      f.input :file, as: :file
+    end
+    f.actions
+
   end
 
 end

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -2,3 +2,4 @@
 #= require activeadmin_addons/all
 #= require ./active_admin_sidekiq
 #= require ./active_admin_export_resource
+#= require ./active_admin_export_multiple_workaround

--- a/app/assets/javascripts/active_admin_export_multiple_workaround.js
+++ b/app/assets/javascripts/active_admin_export_multiple_workaround.js
@@ -1,0 +1,32 @@
+$(document).ready(function() {
+    $('a.active-admin-export-multiples-uploaded-file').on('click', function(event){
+        var message;
+        event.stopPropagation(); // prevent Rails UJS click event
+        event.preventDefault();
+        if ((message = $(this).data('confirm'))) {
+            var me = this;
+            ActiveAdmin.modal_dialog(message, $(this).data('inputs'), function(inputs) {
+                $(me).trigger('confirm:complete', inputs);
+            });
+        } else {
+            $(this).trigger('confirm:complete');
+        }
+    });
+    $('a.active-admin-export-multiples-uploaded-file').on('confirm:complete', function(event, inputs){
+        var href, form, hiddenInput;
+        formData = Object.assign({}, inputs);
+        formData[$('meta[name="csrf-param"]').attr('content')] = $('meta[name="csrf-token"]').attr('content');
+        href = $(this).attr('href');
+        form = $('<form method="POST">');
+        form.attr('action', href);
+        for(attr in formData) {
+            hiddenInput = $("<input type='hidden'>");
+            hiddenInput.attr('name', attr);
+            hiddenInput.attr('value', formData[attr]);
+            form.append(hiddenInput);
+        }
+        $('body').append(form);
+        form.submit();
+    });
+
+});

--- a/app/models/external_system.rb
+++ b/app/models/external_system.rb
@@ -1,6 +1,7 @@
 class ExternalSystem < ApplicationRecord
   self.table_name = :external_systems
 
+  scope :ccd_only, -> { where("reference LIKE 'ccd_%'") }
   has_many :configurations, class_name: 'ExternalSystemConfiguration'
 
   accepts_nested_attributes_for :configurations, reject_if: :all_blank

--- a/app/policies/uploaded_file_policy.rb
+++ b/app/policies/uploaded_file_policy.rb
@@ -20,4 +20,8 @@ class UploadedFilePolicy < ApplicationPolicy
   def destroy?
     user.is_admin? || user.permission_names.include?('delete_uploaded_file')
   end
+
+  def create?
+    user.is_admin? || user.permission_names.include?('create_uploaded_file')
+  end
 end

--- a/app/policies/uploaded_file_policy.rb
+++ b/app/policies/uploaded_file_policy.rb
@@ -24,4 +24,8 @@ class UploadedFilePolicy < ApplicationPolicy
   def create?
     user.is_admin? || user.permission_names.include?('create_uploaded_file')
   end
+
+  def export_ccd_multiples?
+    user.is_admin?
+  end
 end


### PR DESCRIPTION


### JIRA link (if applicable) ###

RST-2318

### Change description ###

This PR is seen as temporary functionality which can be removed once all migrations to CCD are done.
It allows a special multiples CSV file prepared by the ethos replacement team to be read - this code will then send the cases on to CCD.

[ ] Yes
[X] No
```
