### PR TITLE
 …The claims view now gets its state etc.. from the events

### DIFF
--- a/app/models/export_event.rb
+++ b/app/models/export_event.rb
@@ -3,4 +3,8 @@ class ExportEvent < ApplicationRecord
   belongs_to :export
 
   scope :sub_case_exported, -> { where(message: 'Sub case exported') }
+  scope :complete, -> { where(state: 'complete') }
+  scope :in_progress, -> { where(state: 'in_progress') }
+  scope :failed, -> { where(state: 'failed') }
+  scope :erroring, -> { where(state: 'erroring') }
 end


### PR DESCRIPTION



### JIRA link (if applicable) ###
RST-2425


### Change description ###
The claims view now gets its state etc.. from the events rather than relying on the API to update the export record which got out of sync when things happened quickly and got out of sync




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
